### PR TITLE
Run program with custom "smart-vds" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "devDependencies": {
     "jest": "^27.2.2"
   },
+  "bin": {
+    "smart-vds": "./smart-vds.js"
+  },
   "dependencies": {
     "@solidity-parser/parser": "^0.13.2",
     "chalk": "^4.1.2",

--- a/smart-vds.js
+++ b/smart-vds.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const chalk = require('chalk');
 const clear = require('clear');
 const figlet = require('figlet');
@@ -34,7 +36,7 @@ const scan = async () => {
         const fileContents = fileUtils.readFileContents(filePath).toString();
 
         // Generate parse tree from retrieved file contents
-        console.log('Parsing Solidity source code...');
+        console.log(chalk.greenBright('Parsing Solidity source code...'));
         const parseTree = parser.parse(fileContents);
         console.log(parseTree);
     } catch (err) {


### PR DESCRIPTION
Add bin section to package.json and add shebang statement to smart-vds.js to enable the program to be run with the `smart-vds` command.

Must run `npm install -g` before running `smart-vds` command.