### PR TITLE
VDS-67: Slow runtime for jest (unit test framework)

### DIFF
--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const db = require('../utils/databaseUtils');
+
+afterAll(async () => await db.closeDbConnection())
+
+describe('Test Cloud Database', () => {
+  it('DB Connection', async () => {
+    // Arrange
+    let isConnected
+
+    // Act
+    try {
+      isConnected = await db.establishDbConnection()
+    } catch (err) {
+      assert(err.message).toEqual('DB connection error')
+    }
+
+    // Assert
+    assert.equal(isConnected, true)
+  })
+})

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const db = require('../utils/databaseUtils');
+const assert = require('assert')
+const db = require('../utils/databaseUtils')
 
 afterAll(async () => await db.closeDbConnection())
 

--- a/tests/vulnerability-detectors.test.js
+++ b/tests/vulnerability-detectors.test.js
@@ -5,31 +5,13 @@ const file = require('../utils/fileUtils')
 const parser = require('@solidity-parser/parser')
 const vulnerabilityDetectors = require('../utils/vulnerabilityDetectors')
 const { vulnerabilities } = require('../const/vulnerabilities')
-const { vulnerabilityScanner } = require('../vulnerability-scanner')
 
 afterAll(async () => await db.closeDbConnection())
-
-// Test MongoDB Cloud Database
-describe('Test Cloud Database', () => {
-  it('DB Connection', async () => {
-    // Arrange
-    let isConnected
-
-    // Act
-    try {
-      isConnected = await db.establishDbConnection()
-    } catch (err) {
-      assert(err.message).toEqual('DB connection error')
-    }
-
-    // Assert
-    assert.equal(isConnected, true)
-  })
-})
 
 describe('Test reentrancy (SWC-107) vulnerability detector', () => {
   it('should detect one vulnerable function call', async () => {
     // eslint-disable-next-line no-useless-catch
+    jest.setTimeout(10000)
     try {
       const parseTreeFile = fs.readFileSync('tests/resources/json/ReentrancyParseTree.json', {
         encoding: 'utf-8',
@@ -596,7 +578,6 @@ describe('Test Overflow Vulnerability', () => {
     const patterns = await db.retrievePatterns(vulnerabilities.INT_OVERFLOW)
     const OverflowFound = vulnerabilityDetectors.detectOverFlow(parseTree, patterns)
     assert.equal(OverflowFound[0], 1, 'Vulnerability Overflow is not found in Smart Contract.')
-    console.log(OverflowFound[1])
   })
 
   // Overflow condition found in if condition in Smart Contract with expression a += b
@@ -608,124 +589,5 @@ describe('Test Overflow Vulnerability', () => {
     const patterns = await db.retrievePatterns(vulnerabilities.INT_OVERFLOW)
     const OverflowFound = vulnerabilityDetectors.detectOverFlow(parseTree, patterns)
     assert.equal(OverflowFound[0], 1, 'Vulnerability Overflow is not found in Smart Contract.')
-  })
-})
-
-describe('Test function that runs and aggregates the results of all vulnerability detectors', () => {
-  it('should detect one floating pragma vulnerability and one reentrancy vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner1.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 2)
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.REENTRANCY)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-  })
-
-  it('should detect one floating pragma vulnerability and one outdated compiler vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner2.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 2)
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-  })
-
-  it('should detect one floating pragma vulnerability, one outdated compiler vulnerability, and one unchecked call return value vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner3.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 3)
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.UNCHECKED_CALL_RETURN_VALUE)
-    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
-  })
-
-  it('should detect three tx.origin vulnerabilities and one hardcoded gas amount vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner4.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 2)
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.AUTH_THROUGH_TX_ORIGIN)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 3)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.HARDCODED_GAS_AMOUNT)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-  })
-
-  it('should detect one overflow vulnerability, one underflow vulnerability, one outdated compiler vulnerability, and one reentrancy vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner5.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 4)
-
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.INT_OVERFLOW)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.INT_UNDERFLOW)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
-    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[3].vid, vulnerabilities.REENTRANCY)
-    assert.equal(vulnerabilitiesDetected[3].object.length, 1)
-  })
-
-  it('should detect all seven of the detectable vulnerability types: ' +
-      'two tx.origin vulnerabilities, one floating pragma vulnerability, ' +
-      'one hardcoded gas amount vulnerability, one integer overflow vulnerability, ' +
-      'one integer underflow vulnerability, one outdated compiler vulnerability, ' +
-      'one reentrancy vulnerability, and one unchecked call return value vulnerability', async () => {
-    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScannerAll.sol'
-    const fileContents = file.readFileContents(solidityFile).toString()
-    const parseTree = parser.parse(fileContents)
-    await db.establishDbConnection()
-    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
-    assert.equal(vulnerabilitiesDetected.length, 8)
-
-    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.AUTH_THROUGH_TX_ORIGIN)
-    assert.equal(vulnerabilitiesDetected[0].object.length, 2)
-
-    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.FLOATING_PRAGMA)
-    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.HARDCODED_GAS_AMOUNT)
-    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[3].vid, vulnerabilities.INT_OVERFLOW)
-    assert.equal(vulnerabilitiesDetected[3].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[4].vid, vulnerabilities.INT_UNDERFLOW)
-    assert.equal(vulnerabilitiesDetected[4].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[5].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
-    assert.equal(vulnerabilitiesDetected[5].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[6].vid, vulnerabilities.REENTRANCY)
-    assert.equal(vulnerabilitiesDetected[6].object.length, 1)
-
-    assert.equal(vulnerabilitiesDetected[7].vid, vulnerabilities.UNCHECKED_CALL_RETURN_VALUE)
-    assert.equal(vulnerabilitiesDetected[7].object.length, 1)
   })
 })

--- a/tests/vulnerability-detectors.test.js
+++ b/tests/vulnerability-detectors.test.js
@@ -10,8 +10,8 @@ afterAll(async () => await db.closeDbConnection())
 
 describe('Test reentrancy (SWC-107) vulnerability detector', () => {
   it('should detect one vulnerable function call', async () => {
-    // eslint-disable-next-line no-useless-catch
     jest.setTimeout(10000)
+    // eslint-disable-next-line no-useless-catch
     try {
       const parseTreeFile = fs.readFileSync('tests/resources/json/ReentrancyParseTree.json', {
         encoding: 'utf-8',

--- a/tests/vulnerability-scanner.test.js
+++ b/tests/vulnerability-scanner.test.js
@@ -1,0 +1,128 @@
+const file = require('../utils/fileUtils')
+const parser = require('@solidity-parser/parser')
+const db = require('../utils/databaseUtils')
+const { vulnerabilityScanner } = require('../vulnerability-scanner')
+const assert = require('assert')
+const { vulnerabilities } = require('../const/vulnerabilities')
+
+afterAll(async () => await db.closeDbConnection())
+
+describe('Test function that runs and aggregates the results of all vulnerability detectors', () => {
+  it('should detect one floating pragma vulnerability and one reentrancy vulnerability', async () => {
+    jest.setTimeout(10000)
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner1.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 2)
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.REENTRANCY)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+  })
+
+  it('should detect one floating pragma vulnerability and one outdated compiler vulnerability', async () => {
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner2.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 2)
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+  })
+
+  it('should detect one floating pragma vulnerability, one outdated compiler vulnerability, and one unchecked call return value vulnerability', async () => {
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner3.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 3)
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.FLOATING_PRAGMA)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.UNCHECKED_CALL_RETURN_VALUE)
+    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
+  })
+
+  it('should detect three tx.origin vulnerabilities and one hardcoded gas amount vulnerability', async () => {
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner4.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 2)
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.AUTH_THROUGH_TX_ORIGIN)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 3)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.HARDCODED_GAS_AMOUNT)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+  })
+
+  it('should detect one overflow vulnerability, one underflow vulnerability, one outdated compiler vulnerability, and one reentrancy vulnerability', async () => {
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScanner5.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 4)
+
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.INT_OVERFLOW)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.INT_UNDERFLOW)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
+    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[3].vid, vulnerabilities.REENTRANCY)
+    assert.equal(vulnerabilitiesDetected[3].object.length, 1)
+  })
+
+  it('should detect all seven of the detectable vulnerability types: ' +
+    'two tx.origin vulnerabilities, one floating pragma vulnerability, ' +
+    'one hardcoded gas amount vulnerability, one integer overflow vulnerability, ' +
+    'one integer underflow vulnerability, one outdated compiler vulnerability, ' +
+    'one reentrancy vulnerability, and one unchecked call return value vulnerability', async () => {
+    const solidityFile = 'tests/resources/vulnerabilityScanner/VulnerabilityScannerAll.sol'
+    const fileContents = file.readFileContents(solidityFile).toString()
+    const parseTree = parser.parse(fileContents)
+    await db.establishDbConnection()
+    const vulnerabilitiesDetected = await vulnerabilityScanner(parseTree)
+    assert.equal(vulnerabilitiesDetected.length, 8)
+
+    assert.equal(vulnerabilitiesDetected[0].vid, vulnerabilities.AUTH_THROUGH_TX_ORIGIN)
+    assert.equal(vulnerabilitiesDetected[0].object.length, 2)
+
+    assert.equal(vulnerabilitiesDetected[1].vid, vulnerabilities.FLOATING_PRAGMA)
+    assert.equal(vulnerabilitiesDetected[1].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[2].vid, vulnerabilities.HARDCODED_GAS_AMOUNT)
+    assert.equal(vulnerabilitiesDetected[2].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[3].vid, vulnerabilities.INT_OVERFLOW)
+    assert.equal(vulnerabilitiesDetected[3].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[4].vid, vulnerabilities.INT_UNDERFLOW)
+    assert.equal(vulnerabilitiesDetected[4].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[5].vid, vulnerabilities.OUTDATED_COMPILER_VERSION)
+    assert.equal(vulnerabilitiesDetected[5].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[6].vid, vulnerabilities.REENTRANCY)
+    assert.equal(vulnerabilitiesDetected[6].object.length, 1)
+
+    assert.equal(vulnerabilitiesDetected[7].vid, vulnerabilities.UNCHECKED_CALL_RETURN_VALUE)
+    assert.equal(vulnerabilitiesDetected[7].object.length, 1)
+  })
+})


### PR DESCRIPTION
Broke up our one test file into three test files for multiple test suites. Improves the runtime and decreases chances of timeout errors. All changes:
- Created database test file
- Renamed test.js to vulnerability-detectors.test.js
- Created vulnerability scanner test file
- Moved unit test for database and vulnerability scanner to their new test files
- Deleted unnecessary comment in unit test